### PR TITLE
Alert when Aave health factor drops

### DIFF
--- a/backend/src/main/java/app/dya/api/AlertsController.java
+++ b/backend/src/main/java/app/dya/api/AlertsController.java
@@ -1,8 +1,17 @@
 package app.dya.api;
 
-import app.dya.api.dto.*;
-import org.springframework.web.bind.annotation.*;
+import app.dya.api.dto.AlertItem;
+import app.dya.api.dto.AlertsResponse;
+import app.dya.service.AaveV3Service;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 
 @RestController
@@ -10,15 +19,35 @@ import java.util.List;
 @CrossOrigin(origins = "http://localhost:5173")
 public class AlertsController {
 
+    private static final BigDecimal WARNING_THRESHOLD = new BigDecimal("1.3");
+    private static final BigDecimal CRITICAL_THRESHOLD = new BigDecimal("1.0");
+
+    private final AaveV3Service aaveV3Service;
+
+    public AlertsController(AaveV3Service aaveV3Service) {
+        this.aaveV3Service = aaveV3Service;
+    }
+
     @GetMapping("/{address}")
     public AlertsResponse getAlerts(@PathVariable String address) {
-        // TODO: implement rules & state
-        return new AlertsResponse(
-                address,
-                List.of(new AlertItem("HEALTH_FACTOR_LOW",
-                        "Health factor below 1.3 on Aave position",
-                        "Aave",
-                        Instant.now().toString()))
-        );
+        BigDecimal healthFactor = aaveV3Service.getHealthFactor(address);
+        List<AlertItem> alerts = new ArrayList<>();
+        Instant now = Instant.now();
+
+        if (healthFactor.compareTo(CRITICAL_THRESHOLD) < 0) {
+            alerts.add(new AlertItem(
+                    "HEALTH_FACTOR_CRITICAL",
+                    String.format("Health factor %.2f below %.1f on Aave position", healthFactor, CRITICAL_THRESHOLD),
+                    "Aave",
+                    now.toString()));
+        } else if (healthFactor.compareTo(WARNING_THRESHOLD) < 0) {
+            alerts.add(new AlertItem(
+                    "HEALTH_FACTOR_LOW",
+                    String.format("Health factor %.2f below %.1f on Aave position", healthFactor, WARNING_THRESHOLD),
+                    "Aave",
+                    now.toString()));
+        }
+
+        return new AlertsResponse(address, alerts);
     }
 }

--- a/backend/src/main/java/app/dya/service/AaveV3Service.java
+++ b/backend/src/main/java/app/dya/service/AaveV3Service.java
@@ -1,0 +1,30 @@
+package app.dya.service;
+
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+
+/**
+ * Service responsible for interactions with the Aave V3 protocol.
+ *
+ * <p>This is currently a minimal stub and should be expanded with real
+ * integration logic. For now it simply returns a default health factor
+ * allowing the rest of the application to be wired and tested.</p>
+ */
+@Service
+public class AaveV3Service {
+
+    /**
+     * Retrieve the health factor for a wallet. The health factor indicates the
+     * safety of a user's borrow position on Aave, where values below 1.0 are
+     * subject to liquidation.
+     *
+     * @param address the wallet address to query
+     * @return the health factor as reported by Aave
+     */
+    public BigDecimal getHealthFactor(String address) {
+        // TODO: implement integration with Aave to retrieve actual value
+        return BigDecimal.ONE;
+    }
+}
+

--- a/backend/src/test/java/app/dya/api/AlertsControllerTest.java
+++ b/backend/src/test/java/app/dya/api/AlertsControllerTest.java
@@ -1,0 +1,56 @@
+package app.dya.api;
+
+import app.dya.service.AaveV3Service;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AlertsController.class)
+class AlertsControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AaveV3Service aaveV3Service;
+
+    @Test
+    void emitsWarningAlertWhenHealthFactorBelowWarning() throws Exception {
+        when(aaveV3Service.getHealthFactor("0xabc")).thenReturn(new BigDecimal("1.2"));
+
+        mockMvc.perform(get("/alerts/0xabc"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.alerts", hasSize(1)))
+                .andExpect(jsonPath("$.alerts[0].type").value("HEALTH_FACTOR_LOW"));
+    }
+
+    @Test
+    void emitsCriticalAlertWhenHealthFactorBelowCritical() throws Exception {
+        when(aaveV3Service.getHealthFactor("0xabc")).thenReturn(new BigDecimal("0.9"));
+
+        mockMvc.perform(get("/alerts/0xabc"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.alerts", hasSize(1)))
+                .andExpect(jsonPath("$.alerts[0].type").value("HEALTH_FACTOR_CRITICAL"));
+    }
+
+    @Test
+    void noAlertWhenHealthFactorAboveWarning() throws Exception {
+        when(aaveV3Service.getHealthFactor("0xabc")).thenReturn(new BigDecimal("1.5"));
+
+        mockMvc.perform(get("/alerts/0xabc"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.alerts", hasSize(0)));
+    }
+}
+


### PR DESCRIPTION
## Summary
- Inject `AaveV3Service` into `AlertsController`
- Emit alerts when Aave health factor is below warning or critical thresholds
- Add unit tests covering warning, critical, and healthy scenarios

## Testing
- `cd backend && ./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a135e58b808326a52aa1bde69478b6