### PR TITLE
Add health factor and borrow metrics to portfolio DTOs

### DIFF
--- a/backend/src/main/java/app/dya/api/PortfolioController.java
+++ b/backend/src/main/java/app/dya/api/PortfolioController.java
@@ -16,10 +16,22 @@ public class PortfolioController {
         // TODO: wire services (Aave/Compound/Uniswap + price service)
         return new PortfolioDTO(
                 address,
-                new BigDecimal("12345.67"),
+                new BigDecimal("1500"),
+                new BigDecimal("1200"),
+                new BigDecimal("1.8"),
                 List.of(
-                        new PortfolioDTO.PositionDTO("Aave","ethereum","DAI", new BigDecimal("1000"), new BigDecimal("1000"), new BigDecimal("0.045"), "OK"),
-                        new PortfolioDTO.PositionDTO("Compound","ethereum","USDC", new BigDecimal("500"), new BigDecimal("500"), new BigDecimal("0.032"), "OK")
+                        new PortfolioDTO.PositionDTO(
+                                "Aave","ethereum","DAI",
+                                new BigDecimal("1000"), new BigDecimal("1000"), new BigDecimal("0.045"),
+                                new BigDecimal("300"), new BigDecimal("0.025"),
+                                "OK"
+                        ),
+                        new PortfolioDTO.PositionDTO(
+                                "Compound","ethereum","USDC",
+                                new BigDecimal("500"), new BigDecimal("500"), new BigDecimal("0.032"),
+                                BigDecimal.ZERO, BigDecimal.ZERO,
+                                "OK"
+                        )
                 ),
                 Instant.now().toString()
         );

--- a/backend/src/main/java/app/dya/api/dto/PortfolioDTO.java
+++ b/backend/src/main/java/app/dya/api/dto/PortfolioDTO.java
@@ -6,6 +6,8 @@ import java.util.List;
 public record PortfolioDTO(
         String address,
         BigDecimal totalUsd,
+        BigDecimal netWorthUsd,
+        BigDecimal healthFactor,
         List<PositionDTO> positions,
         String lastUpdatedIso
 ) {
@@ -15,7 +17,9 @@ public record PortfolioDTO(
             String asset,         // "DAI", "ETH", "LP-ETH/USDC"
             BigDecimal amount,    // raw units (normalized)
             BigDecimal usdValue,
-            BigDecimal apr,       // as decimal, e.g., 0.045
+            BigDecimal apr,       // deposit APR as decimal, e.g., 0.045
+            BigDecimal borrowAmount,
+            BigDecimal borrowApr,
             String riskStatus     // "OK" | "WARN" | "CRITICAL" (placeholder)
     ) {}
 }

--- a/backend/src/test/java/app/dya/api/PortfolioControllerTest.java
+++ b/backend/src/test/java/app/dya/api/PortfolioControllerTest.java
@@ -1,0 +1,28 @@
+package app.dya.api;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class PortfolioControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void returnsPortfolioWithBorrowFields() throws Exception {
+        mockMvc.perform(get("/portfolio/0xabc"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.healthFactor").value(1.8))
+                .andExpect(jsonPath("$.netWorthUsd").value(1200))
+                .andExpect(jsonPath("$.positions[0].borrowAmount").value(300))
+                .andExpect(jsonPath("$.positions[0].borrowApr").value(0.025));
+    }
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -9,11 +9,15 @@ export type PositionDTO = {
   amount: number
   usdValue: number
   apr: number
+  borrowAmount: number
+  borrowApr: number
   riskStatus: 'OK' | 'WARN' | 'CRITICAL' | string
 }
 export type PortfolioDTO = {
   address: string
   totalUsd: number
+  netWorthUsd?: number
+  healthFactor: number
   positions: PositionDTO[]
   lastUpdatedIso: string
 }


### PR DESCRIPTION
## Summary
- add optional net worth and health factor fields to `PortfolioDTO`
- represent borrow side of positions with `borrowAmount` and `borrowApr`
- update frontend API types and add controller serialization test

## Testing
- `./gradlew test`
- `npm run lint` *(fails: react-refresh/only-export-components in wallet.tsx)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a135e370c48326bfab3c3cbb30ed1e