### PR TITLE
Add Aave V3 portfolio service and controller integration

### DIFF
--- a/backend/src/main/java/app/dya/api/PortfolioController.java
+++ b/backend/src/main/java/app/dya/api/PortfolioController.java
@@ -1,6 +1,7 @@
 package app.dya.api;
 
 import app.dya.api.dto.*;
+import app.dya.service.aave.AaveV3Service;
 import org.springframework.web.bind.annotation.*;
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -11,16 +12,22 @@ import java.util.List;
 @CrossOrigin(origins = "http://localhost:5173")
 public class PortfolioController {
 
+    private final AaveV3Service aaveV3Service;
+
+    public PortfolioController(AaveV3Service aaveV3Service) {
+        this.aaveV3Service = aaveV3Service;
+    }
+
     @GetMapping("/{address}")
     public PortfolioDTO getPortfolio(@PathVariable String address) {
-        // TODO: wire services (Aave/Compound/Uniswap + price service)
+        List<PortfolioDTO.PositionDTO> positions = aaveV3Service.getPositions(address);
+        BigDecimal totalUsd = positions.stream()
+                .map(PortfolioDTO.PositionDTO::usdValue)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
         return new PortfolioDTO(
                 address,
-                new BigDecimal("12345.67"),
-                List.of(
-                        new PortfolioDTO.PositionDTO("Aave","ethereum","DAI", new BigDecimal("1000"), new BigDecimal("1000"), new BigDecimal("0.045"), "OK"),
-                        new PortfolioDTO.PositionDTO("Compound","ethereum","USDC", new BigDecimal("500"), new BigDecimal("500"), new BigDecimal("0.032"), "OK")
-                ),
+                totalUsd,
+                positions,
                 Instant.now().toString()
         );
     }

--- a/backend/src/main/java/app/dya/service/aave/AaveV3Service.java
+++ b/backend/src/main/java/app/dya/service/aave/AaveV3Service.java
@@ -1,0 +1,129 @@
+package app.dya.service.aave;
+
+import app.dya.api.dto.PortfolioDTO;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.math.BigDecimal;
+import java.util.*;
+
+/**
+ * Service fetching positions from the Aave v3 subgraph.
+ *
+ * The implementation is intentionally lightweight and uses {@link RestTemplate}
+ * to query the public subgraph. For unit tests the HTTP layer can be mocked
+ * using {@code MockRestServiceServer}.
+ */
+@Service
+public class AaveV3Service {
+
+    private final RestTemplate restTemplate;
+    private final String subgraphUrl;
+
+    public AaveV3Service(RestTemplateBuilder restTemplateBuilder,
+                         @Value("${aave.v3.subgraph:https://api.thegraph.com/subgraphs/name/aave/protocol-v3}") String subgraphUrl) {
+        this.restTemplate = restTemplateBuilder.build();
+        this.subgraphUrl = subgraphUrl;
+    }
+
+    /**
+     * Returns a list of Aave positions for the given wallet address.
+     */
+    public List<PortfolioDTO.PositionDTO> getPositions(String address) {
+        String query = buildQuery(address);
+        Map<String, Object> response = executeQuery(query);
+        Map<String, Object> user = getUser(response);
+        if (user == null) {
+            return Collections.emptyList();
+        }
+        BigDecimal healthFactor = parseWad((String) user.getOrDefault("healthFactor", "0"));
+        String riskStatus = riskStatus(healthFactor);
+
+        List<Map<String, Object>> reserves = (List<Map<String, Object>>) user.getOrDefault("reserves", Collections.emptyList());
+        List<PortfolioDTO.PositionDTO> positions = new ArrayList<>();
+        for (Map<String, Object> r : reserves) {
+            positions.add(mapReserve(r, riskStatus));
+        }
+        return positions;
+    }
+
+    private String buildQuery(String address) {
+        return """
+                { user(id: \"%s\") {\n"
+                + "  healthFactor\n"
+                + "  reserves: userReserves {\n"
+                + "    scaledATokenBalance\n"
+                + "    scaledVariableDebt\n"
+                + "    reserve { symbol decimals liquidityRate variableBorrowRate price { priceInUsd } }\n"
+                + "  }\n"
+                + "}}""".formatted(address.toLowerCase());
+    }
+
+    private Map<String, Object> executeQuery(String query) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        Map<String, String> body = Map.of("query", query);
+        HttpEntity<Map<String, String>> entity = new HttpEntity<>(body, headers);
+        return restTemplate.postForObject(subgraphUrl, entity, Map.class);
+    }
+
+    private Map<String, Object> getUser(Map<String, Object> response) {
+        if (response == null) return null;
+        Map<String, Object> data = (Map<String, Object>) response.get("data");
+        if (data == null) return null;
+        return (Map<String, Object>) data.get("user");
+    }
+
+    private PortfolioDTO.PositionDTO mapReserve(Map<String, Object> userReserve, String riskStatus) {
+        Map<String, Object> reserve = (Map<String, Object>) userReserve.get("reserve");
+        String symbol = (String) reserve.get("symbol");
+        int decimals = Integer.parseInt(reserve.get("decimals").toString());
+        BigDecimal priceUsd = new BigDecimal(((Map<String, Object>) reserve.get("price")).get("priceInUsd").toString());
+        BigDecimal liquidityRate = parseRay(reserve.get("liquidityRate").toString());
+        BigDecimal variableBorrowRate = parseRay(reserve.get("variableBorrowRate").toString());
+
+        BigDecimal supplied = new BigDecimal(userReserve.getOrDefault("scaledATokenBalance", "0").toString())
+                .movePointLeft(decimals);
+        BigDecimal borrowed = new BigDecimal(userReserve.getOrDefault("scaledVariableDebt", "0").toString())
+                .movePointLeft(decimals);
+
+        BigDecimal netAmount = supplied.subtract(borrowed);
+        BigDecimal usdValue = netAmount.multiply(priceUsd);
+        BigDecimal apr = netAmount.signum() >= 0 ? liquidityRate : variableBorrowRate;
+
+        return new PortfolioDTO.PositionDTO(
+                "Aave",
+                "ethereum",
+                symbol,
+                netAmount,
+                usdValue,
+                apr,
+                riskStatus
+        );
+    }
+
+    private BigDecimal parseRay(String value) {
+        if (value == null) return BigDecimal.ZERO;
+        return new BigDecimal(value).movePointLeft(27);
+    }
+
+    private BigDecimal parseWad(String value) {
+        if (value == null) return BigDecimal.ZERO;
+        return new BigDecimal(value).movePointLeft(18);
+    }
+
+    private String riskStatus(BigDecimal healthFactor) {
+        if (healthFactor.compareTo(new BigDecimal("1.1")) < 0) {
+            return "CRITICAL";
+        } else if (healthFactor.compareTo(new BigDecimal("1.3")) < 0) {
+            return "WARN";
+        }
+        return "OK";
+    }
+}
+

--- a/backend/src/test/java/app/dya/api/PortfolioControllerTest.java
+++ b/backend/src/test/java/app/dya/api/PortfolioControllerTest.java
@@ -1,0 +1,41 @@
+package app.dya.api;
+
+import app.dya.api.dto.PortfolioDTO;
+import app.dya.service.aave.AaveV3Service;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(PortfolioController.class)
+class PortfolioControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AaveV3Service aaveV3Service;
+
+    @Test
+    void returnsPortfolioFromService() throws Exception {
+        List<PortfolioDTO.PositionDTO> positions = List.of(
+                new PortfolioDTO.PositionDTO("Aave","ethereum","DAI", new BigDecimal("90"), new BigDecimal("90"), new BigDecimal("0.05"), "OK")
+        );
+        when(aaveV3Service.getPositions("0xabc")).thenReturn(positions);
+
+        mockMvc.perform(get("/portfolio/0xabc"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.address").value("0xabc"))
+                .andExpect(jsonPath("$.totalUsd").value(90))
+                .andExpect(jsonPath("$.positions[0].asset").value("DAI"));
+    }
+}
+

--- a/backend/src/test/java/app/dya/service/aave/AaveV3ServiceTest.java
+++ b/backend/src/test/java/app/dya/service/aave/AaveV3ServiceTest.java
@@ -1,0 +1,53 @@
+package app.dya.service.aave;
+
+import app.dya.api.dto.PortfolioDTO;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+class AaveV3ServiceTest {
+
+    @Test
+    void parsesPositionsFromSubgraph() {
+        RestTemplate restTemplate = new RestTemplate();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(restTemplate).ignoreExpectOrder(true).build();
+
+        AaveV3Service service = new AaveV3Service(new RestTemplateBuilder() {
+            @Override
+            public RestTemplate build() {
+                return restTemplate;
+            }
+        }, "http://example.com");
+
+        String body = "{" +
+                "\"data\":{\"user\":{\"healthFactor\":\"1300000000000000000\"," +
+                "\"reserves\":[{\"scaledATokenBalance\":\"100000000000000000000\"," +
+                "\"scaledVariableDebt\":\"10000000000000000000\"," +
+                "\"reserve\":{\"symbol\":\"DAI\",\"decimals\":\"18\",\"liquidityRate\":\"50000000000000000000000000\",\"variableBorrowRate\":\"100000000000000000000000000\",\"price\":{\"priceInUsd\":\"1\"}}}]}" +
+                "}}";
+
+        server.expect(requestTo("http://example.com"))
+                .andExpect(method(org.springframework.http.HttpMethod.POST))
+                .andRespond(withSuccess(body, MediaType.APPLICATION_JSON));
+
+        List<PortfolioDTO.PositionDTO> positions = service.getPositions("0xabc");
+        assertThat(positions).hasSize(1);
+        PortfolioDTO.PositionDTO p = positions.get(0);
+        assertThat(p.asset()).isEqualTo("DAI");
+        assertThat(p.amount()).isEqualByComparingTo(new BigDecimal("90"));
+        assertThat(p.apr()).isEqualByComparingTo(new BigDecimal("0.05"));
+        assertThat(p.usdValue()).isEqualByComparingTo(new BigDecimal("90"));
+        assertThat(p.riskStatus()).isEqualTo("OK");
+    }
+}
+


### PR DESCRIPTION
## Summary
- Add `AaveV3Service` to fetch user reserves from Aave v3 subgraph, compute balances, APRs and risk status
- Inject service into `PortfolioController` to return live position data
- Cover service parsing logic and controller mapping with unit tests

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a135e341c8832698931d802e3e14ed