### PR TITLE
Add Compound V2 service tests and controller assertions

### DIFF
--- a/backend/src/main/java/app/dya/service/compound/CompoundV2Service.java
+++ b/backend/src/main/java/app/dya/service/compound/CompoundV2Service.java
@@ -1,19 +1,35 @@
 package app.dya.service.compound;
 
 import app.dya.api.dto.PortfolioDTO;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
 
+import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Service responsible for fetching positions from the Compound v2 protocol.
  *
- * <p>The current implementation is a stub that returns an empty list. It can be
- * expanded with real protocol integration in the future.</p>
+ * <p>The implementation is lightweight and focuses on parsing a minimal
+ * response structure returned by a supplied API endpoint. It can be expanded
+ * with real protocol integration in the future.</p>
  */
 @Service
 public class CompoundV2Service {
+
+    private final RestTemplate restTemplate;
+    private final String apiUrl;
+
+    public CompoundV2Service(RestTemplateBuilder restTemplateBuilder,
+                             @Value("${compound.v2.api:https://api.compound.finance/v2/account}") String apiUrl) {
+        this.restTemplate = restTemplateBuilder.build();
+        this.apiUrl = apiUrl;
+    }
 
     /**
      * Retrieve Compound v2 positions for a given wallet address.
@@ -22,7 +38,65 @@ public class CompoundV2Service {
      * @return list of positions held on Compound v2
      */
     public List<PortfolioDTO.PositionDTO> getPositions(String address) {
-        return Collections.emptyList();
+        String url = String.format("%s/%s", apiUrl, address);
+        Map<String, Object> response = restTemplate.getForObject(url, Map.class);
+        if (response == null) return Collections.emptyList();
+
+        Map<String, Object> account = (Map<String, Object>) response.get("account");
+        if (account == null) return Collections.emptyList();
+
+        List<Map<String, Object>> tokens = (List<Map<String, Object>>) account.getOrDefault("tokens", Collections.emptyList());
+        List<PortfolioDTO.PositionDTO> positions = new ArrayList<>();
+        for (Map<String, Object> token : tokens) {
+            positions.addAll(mapToken(token));
+        }
+        return positions;
+    }
+
+    private List<PortfolioDTO.PositionDTO> mapToken(Map<String, Object> token) {
+        String symbol = token.get("symbol").toString();
+        BigDecimal usdPrice = new BigDecimal(token.getOrDefault("usdPrice", "0").toString());
+        BigDecimal supplyBalance = new BigDecimal(token.getOrDefault("supplyBalance", "0").toString());
+        BigDecimal borrowBalance = new BigDecimal(token.getOrDefault("borrowBalance", "0").toString());
+        BigDecimal supplyRate = new BigDecimal(token.getOrDefault("supplyRate", "0").toString());
+        BigDecimal borrowRate = new BigDecimal(token.getOrDefault("borrowRate", "0").toString());
+
+        List<PortfolioDTO.PositionDTO> positions = new ArrayList<>();
+
+        if (supplyBalance.compareTo(BigDecimal.ZERO) > 0) {
+            BigDecimal usdValue = supplyBalance.multiply(usdPrice);
+            positions.add(new PortfolioDTO.PositionDTO(
+                    "Compound",
+                    "ethereum",
+                    symbol,
+                    supplyBalance,
+                    usdValue,
+                    supplyRate,
+                    BigDecimal.ZERO,
+                    BigDecimal.ZERO,
+                    "OK",
+                    "DEPOSIT"
+            ));
+        }
+
+        if (borrowBalance.compareTo(BigDecimal.ZERO) > 0) {
+            BigDecimal borrowUsd = borrowBalance.multiply(usdPrice);
+            positions.add(new PortfolioDTO.PositionDTO(
+                    "Compound",
+                    "ethereum",
+                    symbol,
+                    borrowBalance,
+                    BigDecimal.ZERO,
+                    BigDecimal.ZERO,
+                    borrowUsd,
+                    borrowRate,
+                    "OK",
+                    "BORROW"
+            ));
+        }
+
+        return positions;
     }
 }
+
 

--- a/backend/src/test/java/app/dya/api/PortfolioControllerTest.java
+++ b/backend/src/test/java/app/dya/api/PortfolioControllerTest.java
@@ -57,8 +57,11 @@ class PortfolioControllerTest {
                 .andExpect(jsonPath("$.netWorthUsd").value(130))
                 .andExpect(jsonPath("$.healthFactor").value(7.5))
                 .andExpect(jsonPath("$.positions.length()").value(3))
+                .andExpect(jsonPath("$.positions[0].protocol").value("Aave"))
                 .andExpect(jsonPath("$.positions[0].positionType").value("DEPOSIT"))
+                .andExpect(jsonPath("$.positions[1].protocol").value("Aave"))
                 .andExpect(jsonPath("$.positions[1].positionType").value("BORROW"))
+                .andExpect(jsonPath("$.positions[2].protocol").value("Compound"))
                 .andExpect(jsonPath("$.positions[2].asset").value("USDC"));
     }
 }

--- a/backend/src/test/java/app/dya/service/compound/CompoundV2ServiceTest.java
+++ b/backend/src/test/java/app/dya/service/compound/CompoundV2ServiceTest.java
@@ -1,0 +1,105 @@
+package app.dya.service.compound;
+
+import app.dya.api.dto.PortfolioDTO;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+class CompoundV2ServiceTest {
+
+    private CompoundV2Service buildService(RestTemplate restTemplate) {
+        return new CompoundV2Service(new RestTemplateBuilder() {
+            @Override
+            public RestTemplate build() {
+                return restTemplate;
+            }
+        }, "http://example.com");
+    }
+
+    @Test
+    void parsesPositionsFromApi() {
+        RestTemplate restTemplate = new RestTemplate();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(restTemplate).ignoreExpectOrder(true).build();
+
+        CompoundV2Service service = buildService(restTemplate);
+
+        String body = "{" +
+                "\"account\":{\"tokens\":[{" +
+                "\"symbol\":\"DAI\",\"supplyBalance\":\"100\",\"borrowBalance\":\"10\"," +
+                "\"supplyRate\":\"0.02\",\"borrowRate\":\"0.04\",\"usdPrice\":\"1\"}]}" +
+                "}";
+
+        server.expect(requestTo("http://example.com/0xabc"))
+                .andExpect(method(org.springframework.http.HttpMethod.GET))
+                .andRespond(withSuccess(body, MediaType.APPLICATION_JSON));
+
+        List<PortfolioDTO.PositionDTO> positions = service.getPositions("0xabc");
+        assertThat(positions).hasSize(2);
+
+        PortfolioDTO.PositionDTO deposit = positions.get(0);
+        assertThat(deposit.protocol()).isEqualTo("Compound");
+        assertThat(deposit.asset()).isEqualTo("DAI");
+        assertThat(deposit.amount()).isEqualByComparingTo(new BigDecimal("100"));
+        assertThat(deposit.usdValue()).isEqualByComparingTo(new BigDecimal("100"));
+        assertThat(deposit.apr()).isEqualByComparingTo(new BigDecimal("0.02"));
+        assertThat(deposit.positionType()).isEqualTo("DEPOSIT");
+
+        PortfolioDTO.PositionDTO borrow = positions.get(1);
+        assertThat(borrow.positionType()).isEqualTo("BORROW");
+        assertThat(borrow.borrowAmount()).isEqualByComparingTo(new BigDecimal("10"));
+        assertThat(borrow.borrowApr()).isEqualByComparingTo(new BigDecimal("0.04"));
+    }
+
+    @Test
+    void returnsEmptyWhenNoTokens() {
+        RestTemplate restTemplate = new RestTemplate();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(restTemplate).build();
+
+        CompoundV2Service service = buildService(restTemplate);
+
+        String body = "{\"account\":{\"tokens\":[]}}";
+
+        server.expect(requestTo("http://example.com/0xabc"))
+                .andExpect(method(org.springframework.http.HttpMethod.GET))
+                .andRespond(withSuccess(body, MediaType.APPLICATION_JSON));
+
+        List<PortfolioDTO.PositionDTO> positions = service.getPositions("0xabc");
+        assertThat(positions).isEmpty();
+    }
+
+    @Test
+    void handlesBorrowOnly() {
+        RestTemplate restTemplate = new RestTemplate();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(restTemplate).build();
+
+        CompoundV2Service service = buildService(restTemplate);
+
+        String body = "{" +
+                "\"account\":{\"tokens\":[{" +
+                "\"symbol\":\"USDC\",\"supplyBalance\":\"0\",\"borrowBalance\":\"20\"," +
+                "\"supplyRate\":\"0\",\"borrowRate\":\"0.03\",\"usdPrice\":\"1\"}]}" +
+                "}";
+
+        server.expect(requestTo("http://example.com/0xabc"))
+                .andExpect(method(org.springframework.http.HttpMethod.GET))
+                .andRespond(withSuccess(body, MediaType.APPLICATION_JSON));
+
+        List<PortfolioDTO.PositionDTO> positions = service.getPositions("0xabc");
+        assertThat(positions).hasSize(1);
+        PortfolioDTO.PositionDTO borrow = positions.get(0);
+        assertThat(borrow.positionType()).isEqualTo("BORROW");
+        assertThat(borrow.asset()).isEqualTo("USDC");
+        assertThat(borrow.borrowAmount()).isEqualByComparingTo(new BigDecimal("20"));
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement CompoundV2Service to fetch and map positions
- add CompoundV2ServiceTest covering parsing and edge cases
- assert protocol names in PortfolioControllerTest

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a2be9aff208326adb5f3fbe32f9ca7