### PR TITLE
Consolidate Aave alert thresholds

### DIFF
--- a/backend/src/main/java/app/dya/api/AlertsController.java
+++ b/backend/src/main/java/app/dya/api/AlertsController.java
@@ -19,8 +19,7 @@ import java.util.List;
 @CrossOrigin(origins = "http://localhost:5173")
 public class AlertsController {
 
-    private static final BigDecimal WARNING_THRESHOLD = new BigDecimal("1.3");
-    private static final BigDecimal CRITICAL_THRESHOLD = new BigDecimal("1.0");
+    private static final BigDecimal RISK_THRESHOLD = new BigDecimal("1.3");
 
     private final AaveV3HealthService aaveV3Service;
 
@@ -34,16 +33,10 @@ public class AlertsController {
         List<AlertItem> alerts = new ArrayList<>();
         Instant now = Instant.now();
 
-        if (healthFactor.compareTo(CRITICAL_THRESHOLD) < 0) {
+        if (healthFactor.compareTo(RISK_THRESHOLD) < 0) {
             alerts.add(new AlertItem(
-                    "HEALTH_FACTOR_CRITICAL",
-                    String.format("Health factor %.2f below %.1f on Aave position", healthFactor, CRITICAL_THRESHOLD),
-                    "Aave",
-                    now.toString()));
-        } else if (healthFactor.compareTo(WARNING_THRESHOLD) < 0) {
-            alerts.add(new AlertItem(
-                    "HEALTH_FACTOR_LOW",
-                    String.format("Health factor %.2f below %.1f on Aave position", healthFactor, WARNING_THRESHOLD),
+                    "LIQUIDATION_RISK",
+                    String.format("Health factor %.2f below 1.3 on Aave position", healthFactor),
                     "Aave",
                     now.toString()));
         }

--- a/backend/src/test/java/app/dya/api/AlertsControllerTest.java
+++ b/backend/src/test/java/app/dya/api/AlertsControllerTest.java
@@ -25,27 +25,28 @@ class AlertsControllerTest {
     private AaveV3HealthService aaveV3Service;
 
     @Test
-    void emitsWarningAlertWhenHealthFactorBelowWarning() throws Exception {
+    void emitsRiskAlertWhenHealthFactorBelowThreshold() throws Exception {
         when(aaveV3Service.getHealthFactor("0xabc")).thenReturn(new BigDecimal("1.2"));
 
         mockMvc.perform(get("/alerts/0xabc"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.alerts", hasSize(1)))
-                .andExpect(jsonPath("$.alerts[0].type").value("HEALTH_FACTOR_LOW"));
+                .andExpect(jsonPath("$.alerts[0].type").value("LIQUIDATION_RISK"))
+                .andExpect(jsonPath("$.alerts[0].message").value("Health factor 1.20 below 1.3 on Aave position"));
     }
 
     @Test
-    void emitsCriticalAlertWhenHealthFactorBelowCritical() throws Exception {
+    void emitsRiskAlertWhenHealthFactorFarBelowThreshold() throws Exception {
         when(aaveV3Service.getHealthFactor("0xabc")).thenReturn(new BigDecimal("0.9"));
 
         mockMvc.perform(get("/alerts/0xabc"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.alerts", hasSize(1)))
-                .andExpect(jsonPath("$.alerts[0].type").value("HEALTH_FACTOR_CRITICAL"));
+                .andExpect(jsonPath("$.alerts[0].type").value("LIQUIDATION_RISK"));
     }
 
     @Test
-    void noAlertWhenHealthFactorAboveWarning() throws Exception {
+    void noAlertWhenHealthFactorAboveThreshold() throws Exception {
         when(aaveV3Service.getHealthFactor("0xabc")).thenReturn(new BigDecimal("1.5"));
 
         mockMvc.perform(get("/alerts/0xabc"))


### PR DESCRIPTION
## Summary
- replace separate warning and critical health factor thresholds with single `RISK_THRESHOLD`
- emit `LIQUIDATION_RISK` alert when health factor falls below 1.3
- update tests for new threshold and alert message

## Testing
- `cd backend && ./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a5081101a483269e2d62383ed5a758