### PR TITLE
feat: track APY drops

### DIFF
--- a/backend/src/main/java/app/dya/api/AlertsController.java
+++ b/backend/src/main/java/app/dya/api/AlertsController.java
@@ -2,7 +2,12 @@ package app.dya.api;
 
 import app.dya.api.dto.AlertItem;
 import app.dya.api.dto.AlertsResponse;
+import app.dya.api.dto.PortfolioDTO;
 import app.dya.service.AaveV3HealthService;
+import app.dya.service.ApyTrackingService;
+import app.dya.service.aave.AaveV3Service;
+import app.dya.service.compound.CompoundV2Service;
+import app.dya.service.uniswap.UniswapV3Service;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -21,15 +26,27 @@ public class AlertsController {
 
     private static final BigDecimal RISK_THRESHOLD = new BigDecimal("1.3");
 
-    private final AaveV3HealthService aaveV3Service;
+    private final AaveV3HealthService aaveV3HealthService;
+    private final AaveV3Service aaveV3Service;
+    private final CompoundV2Service compoundV2Service;
+    private final UniswapV3Service uniswapV3Service;
+    private final ApyTrackingService apyTrackingService;
 
-    public AlertsController(AaveV3HealthService aaveV3Service) {
+    public AlertsController(AaveV3HealthService aaveV3HealthService,
+                            AaveV3Service aaveV3Service,
+                            CompoundV2Service compoundV2Service,
+                            UniswapV3Service uniswapV3Service,
+                            ApyTrackingService apyTrackingService) {
+        this.aaveV3HealthService = aaveV3HealthService;
         this.aaveV3Service = aaveV3Service;
+        this.compoundV2Service = compoundV2Service;
+        this.uniswapV3Service = uniswapV3Service;
+        this.apyTrackingService = apyTrackingService;
     }
 
     @GetMapping("/{address}")
     public AlertsResponse getAlerts(@PathVariable String address) {
-        BigDecimal healthFactor = aaveV3Service.getHealthFactor(address);
+        BigDecimal healthFactor = aaveV3HealthService.getHealthFactor(address);
         List<AlertItem> alerts = new ArrayList<>();
         Instant now = Instant.now();
 
@@ -39,6 +56,17 @@ public class AlertsController {
                     String.format("Health factor %.2f below 1.3 on Aave position", healthFactor),
                     "Aave",
                     now.toString()));
+        }
+
+        List<PortfolioDTO.PositionDTO> positions = new ArrayList<>();
+        positions.addAll(aaveV3Service.getPositions(address));
+        positions.addAll(compoundV2Service.getPositions(address));
+        positions.addAll(uniswapV3Service.getPositions(address));
+
+        for (PortfolioDTO.PositionDTO pos : positions) {
+            if ("DEPOSIT".equalsIgnoreCase(pos.positionType())) {
+                apyTrackingService.checkApy(address, pos).ifPresent(alerts::add);
+            }
         }
 
         return new AlertsResponse(address, alerts);

--- a/backend/src/main/java/app/dya/service/ApyTrackingService.java
+++ b/backend/src/main/java/app/dya/service/ApyTrackingService.java
@@ -1,0 +1,48 @@
+package app.dya.service;
+
+import app.dya.api.dto.AlertItem;
+import app.dya.api.dto.PortfolioDTO;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Tracks historical APRs for positions to detect significant yield drops.
+ */
+@Service
+public class ApyTrackingService {
+
+    private final ConcurrentHashMap<String, BigDecimal> lastApr = new ConcurrentHashMap<>();
+
+    /**
+     * Check APR for the given position and emit an alert if it dropped more than 20% since
+     * the last observation.
+     *
+     * @param addr wallet address
+     * @param pos  portfolio position
+     * @return optional alert when APR decreased significantly
+     */
+    public Optional<AlertItem> checkApy(String addr, PortfolioDTO.PositionDTO pos) {
+        BigDecimal currentApr = pos.apr() == null ? BigDecimal.ZERO : pos.apr();
+        String key = String.join(":", addr, pos.protocol(), pos.asset(), pos.positionType());
+        BigDecimal previous = lastApr.put(key, currentApr);
+        if (previous != null && currentApr.compareTo(previous.multiply(new BigDecimal("0.8"))) < 0) {
+            String message = String.format("APR dropped from %.2f%% to %.2f%% on %s %s", 
+                    previous.multiply(BigDecimal.valueOf(100)),
+                    currentApr.multiply(BigDecimal.valueOf(100)),
+                    pos.protocol(),
+                    pos.asset());
+            AlertItem alert = new AlertItem(
+                    "YIELD_DROP",
+                    message,
+                    pos.protocol(),
+                    Instant.now().toString()
+            );
+            return Optional.of(alert);
+        }
+        return Optional.empty();
+    }
+}

--- a/backend/src/test/java/app/dya/api/AlertsControllerTest.java
+++ b/backend/src/test/java/app/dya/api/AlertsControllerTest.java
@@ -1,6 +1,10 @@
 package app.dya.api;
 
 import app.dya.service.AaveV3HealthService;
+import app.dya.service.ApyTrackingService;
+import app.dya.service.aave.AaveV3Service;
+import app.dya.service.compound.CompoundV2Service;
+import app.dya.service.uniswap.UniswapV3Service;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -22,11 +26,22 @@ class AlertsControllerTest {
     private MockMvc mockMvc;
 
     @MockBean
-    private AaveV3HealthService aaveV3Service;
+    private AaveV3HealthService aaveV3HealthService;
+    @MockBean
+    private AaveV3Service aaveV3Service;
+    @MockBean
+    private CompoundV2Service compoundV2Service;
+    @MockBean
+    private UniswapV3Service uniswapV3Service;
+    @MockBean
+    private ApyTrackingService apyTrackingService;
 
     @Test
     void emitsRiskAlertWhenHealthFactorBelowThreshold() throws Exception {
-        when(aaveV3Service.getHealthFactor("0xabc")).thenReturn(new BigDecimal("1.2"));
+        when(aaveV3HealthService.getHealthFactor("0xabc")).thenReturn(new BigDecimal("1.2"));
+        when(aaveV3Service.getPositions("0xabc")).thenReturn(java.util.Collections.emptyList());
+        when(compoundV2Service.getPositions("0xabc")).thenReturn(java.util.Collections.emptyList());
+        when(uniswapV3Service.getPositions("0xabc")).thenReturn(java.util.Collections.emptyList());
 
         mockMvc.perform(get("/alerts/0xabc"))
                 .andExpect(status().isOk())
@@ -37,7 +52,10 @@ class AlertsControllerTest {
 
     @Test
     void emitsRiskAlertWhenHealthFactorFarBelowThreshold() throws Exception {
-        when(aaveV3Service.getHealthFactor("0xabc")).thenReturn(new BigDecimal("0.9"));
+        when(aaveV3HealthService.getHealthFactor("0xabc")).thenReturn(new BigDecimal("0.9"));
+        when(aaveV3Service.getPositions("0xabc")).thenReturn(java.util.Collections.emptyList());
+        when(compoundV2Service.getPositions("0xabc")).thenReturn(java.util.Collections.emptyList());
+        when(uniswapV3Service.getPositions("0xabc")).thenReturn(java.util.Collections.emptyList());
 
         mockMvc.perform(get("/alerts/0xabc"))
                 .andExpect(status().isOk())
@@ -47,7 +65,10 @@ class AlertsControllerTest {
 
     @Test
     void noAlertWhenHealthFactorAboveThreshold() throws Exception {
-        when(aaveV3Service.getHealthFactor("0xabc")).thenReturn(new BigDecimal("1.5"));
+        when(aaveV3HealthService.getHealthFactor("0xabc")).thenReturn(new BigDecimal("1.5"));
+        when(aaveV3Service.getPositions("0xabc")).thenReturn(java.util.Collections.emptyList());
+        when(compoundV2Service.getPositions("0xabc")).thenReturn(java.util.Collections.emptyList());
+        when(uniswapV3Service.getPositions("0xabc")).thenReturn(java.util.Collections.emptyList());
 
         mockMvc.perform(get("/alerts/0xabc"))
                 .andExpect(status().isOk())

--- a/backend/src/test/java/app/dya/service/ApyTrackingServiceTest.java
+++ b/backend/src/test/java/app/dya/service/ApyTrackingServiceTest.java
@@ -1,0 +1,47 @@
+package app.dya.service;
+
+import app.dya.api.dto.AlertItem;
+import app.dya.api.dto.PortfolioDTO;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ApyTrackingServiceTest {
+
+    @Test
+    void detectsYieldDrop() {
+        ApyTrackingService service = new ApyTrackingService();
+        PortfolioDTO.PositionDTO initial = new PortfolioDTO.PositionDTO(
+                "Aave",
+                "ethereum",
+                "DAI",
+                BigDecimal.ONE,
+                BigDecimal.ONE,
+                new BigDecimal("0.10"),
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                "OK",
+                "DEPOSIT"
+        );
+        PortfolioDTO.PositionDTO lower = new PortfolioDTO.PositionDTO(
+                "Aave",
+                "ethereum",
+                "DAI",
+                BigDecimal.ONE,
+                BigDecimal.ONE,
+                new BigDecimal("0.05"),
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                "OK",
+                "DEPOSIT"
+        );
+        Optional<AlertItem> first = service.checkApy("0xabc", initial);
+        assertTrue(first.isEmpty());
+        Optional<AlertItem> alert = service.checkApy("0xabc", lower);
+        assertTrue(alert.isPresent());
+        assertEquals("YIELD_DROP", alert.get().type());
+    }
+}


### PR DESCRIPTION
## Summary
- add in-memory ApyTrackingService to watch APR changes
- wire ApyTrackingService and protocol services into AlertsController to report yield drops
- cover new service with unit tests and update alerts tests

## Testing
- `cd backend && ./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68a50a47f9288326b06c8efebcdea8c7