### PR TITLE
Add daily yield USD calculation to portfolio

### DIFF
--- a/backend/src/main/java/app/dya/api/PortfolioController.java
+++ b/backend/src/main/java/app/dya/api/PortfolioController.java
@@ -49,10 +49,22 @@ public class PortfolioController {
                 ? totalUsd.divide(totalBorrowUsd, 2, RoundingMode.HALF_UP)
                 : BigDecimal.ZERO;
 
+        BigDecimal dailyYieldUsd = BigDecimal.ZERO;
+        for (PortfolioDTO.PositionDTO p : positions) {
+            BigDecimal depositYield = p.usdValue()
+                    .multiply(p.apr())
+                    .divide(BigDecimal.valueOf(365), 18, RoundingMode.HALF_UP);
+            BigDecimal borrowCost = p.borrowAmount()
+                    .multiply(p.borrowApr())
+                    .divide(BigDecimal.valueOf(365), 18, RoundingMode.HALF_UP);
+            dailyYieldUsd = dailyYieldUsd.add(depositYield).subtract(borrowCost);
+        }
+
         return new PortfolioDTO(
                 address,
                 totalUsd,
                 netWorthUsd,
+                dailyYieldUsd,
                 healthFactor,
                 positions,
                 Instant.now().toString()

--- a/backend/src/main/java/app/dya/api/dto/PortfolioDTO.java
+++ b/backend/src/main/java/app/dya/api/dto/PortfolioDTO.java
@@ -7,6 +7,7 @@ public record PortfolioDTO(
         String address,
         BigDecimal totalUsd,
         BigDecimal netWorthUsd,
+        BigDecimal dailyYieldUsd,
         BigDecimal healthFactor,
         List<PositionDTO> positions,
         String lastUpdatedIso

--- a/backend/src/test/java/app/dya/api/PortfolioControllerTest.java
+++ b/backend/src/test/java/app/dya/api/PortfolioControllerTest.java
@@ -37,17 +37,17 @@ class PortfolioControllerTest {
         List<PortfolioDTO.PositionDTO> aavePositions = List.of(
                 new PortfolioDTO.PositionDTO(
                         "Aave", "ethereum", "DAI",
-                        new BigDecimal("100"), new BigDecimal("100"), new BigDecimal("0.05"),
+                        new BigDecimal("100"), new BigDecimal("100"), new BigDecimal("0.365"),
                         BigDecimal.ZERO, BigDecimal.ZERO, "OK", "DEPOSIT"),
                 new PortfolioDTO.PositionDTO(
                         "Aave", "ethereum", "DAI",
                         new BigDecimal("20"), BigDecimal.ZERO, BigDecimal.ZERO,
-                        new BigDecimal("20"), new BigDecimal("0.03"), "OK", "BORROW")
+                        new BigDecimal("20"), new BigDecimal("0.1825"), "OK", "BORROW")
         );
         List<PortfolioDTO.PositionDTO> compoundPositions = List.of(
                 new PortfolioDTO.PositionDTO(
                         "Compound", "ethereum", "USDC",
-                        new BigDecimal("50"), new BigDecimal("50"), new BigDecimal("0.02"),
+                        new BigDecimal("50"), new BigDecimal("50"), new BigDecimal("0.365"),
                         BigDecimal.ZERO, BigDecimal.ZERO, "OK", "DEPOSIT")
         );
 
@@ -60,6 +60,7 @@ class PortfolioControllerTest {
                 .andExpect(jsonPath("$.address").value("0xabc"))
                 .andExpect(jsonPath("$.totalUsd").value(150))
                 .andExpect(jsonPath("$.netWorthUsd").value(130))
+                .andExpect(jsonPath("$.dailyYieldUsd").value(0.14))
                 .andExpect(jsonPath("$.healthFactor").value(7.5))
                 .andExpect(jsonPath("$.positions.length()").value(3))
                 .andExpect(jsonPath("$.positions[0].protocol").value("Aave"))


### PR DESCRIPTION
## Summary
- track dailyYieldUsd in PortfolioDTO
- compute portfolio daily yield in PortfolioController
- test dailyYieldUsd aggregation in PortfolioControllerTest

## Testing
- `cd backend && ./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68a68fa4ac5c83268125aa5ed075099c