### PR TITLE
feat: implement auto refresh for prices and portfolio

### DIFF
--- a/backend/src/main/java/app/dya/DyaBackendApplication.java
+++ b/backend/src/main/java/app/dya/DyaBackendApplication.java
@@ -2,8 +2,10 @@ package app.dya;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class DyaBackendApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/app/dya/price/PriceRefreshScheduler.java
+++ b/backend/src/main/java/app/dya/price/PriceRefreshScheduler.java
@@ -1,0 +1,31 @@
+package app.dya.price;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Component
+@ConditionalOnExpression("${app.prices.refreshMinutes:0} > 0")
+public class PriceRefreshScheduler {
+    private final PriceService priceService;
+
+    public PriceRefreshScheduler(PriceService priceService) {
+        this.priceService = priceService;
+    }
+
+    @Scheduled(
+            fixedRateString = "#{${app.prices.refreshMinutes} * 60 * 1000}",
+            initialDelayString = "#{${app.prices.refreshMinutes} * 60 * 1000}"
+    )
+    public void refresh() {
+        List<String> symbols = Arrays.stream(Symbol.values()).map(Enum::name).toList();
+        try {
+            priceService.getUsdPrices(symbols);
+        } catch (Exception ignored) {
+            // ignore refresh errors
+        }
+    }
+}

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -13,6 +13,7 @@ app:
     baseUrl: ${COINGECKO_BASE_URL:https://api.coingecko.com/api/v3}
     cacheTtlMinutes: ${PRICE_CACHE_TTL_MINUTES:10}
     demoApiKey: ${COINGECKO_DEMO_API_KEY:CG-kQ575HU7YYQynEFkSyiaRnyA}
+    refreshMinutes: ${PRICE_REFRESH_MINUTES:0}
   http:
     connectTimeoutMillis: 3000
     readTimeoutMillis: 4000


### PR DESCRIPTION
## Summary
- enable backend scheduling and add optional price refresh scheduler
- add frontend refresh button, timestamp, and 5-minute auto-refresh

## Testing
- `./gradlew test`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9119f72d48326bd42ee5434d20f76