### PR TITLE
Handle CoinGecko rate limit

### DIFF
--- a/backend/src/main/java/app/dya/price/CoinGeckoClientException.java
+++ b/backend/src/main/java/app/dya/price/CoinGeckoClientException.java
@@ -1,0 +1,14 @@
+package app.dya.price;
+
+public class CoinGeckoClientException extends RuntimeException {
+    private final int statusCode;
+
+    public CoinGeckoClientException(int statusCode, String message, Throwable cause) {
+        super(message, cause);
+        this.statusCode = statusCode;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+}

--- a/backend/src/test/java/app/dya/price/CoinGeckoClientTest.java
+++ b/backend/src/test/java/app/dya/price/CoinGeckoClientTest.java
@@ -1,0 +1,36 @@
+package app.dya.price;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.test.web.client.match.MockRestRequestMatchers;
+import org.springframework.test.web.client.response.MockRestResponseCreators;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CoinGeckoClientTest {
+
+    @Test
+    void returnsEmptyMapOnRateLimit() {
+        RestClient.Builder builder = RestClient.builder().baseUrl("http://localhost");
+        MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+
+        CoinGeckoClient client = new CoinGeckoClient(
+                "http://localhost", null, null, 1000, 1000, null, 0
+        );
+        ReflectionTestUtils.setField(client, "rest", builder.build());
+
+        server.expect(MockRestRequestMatchers.anything())
+                .andRespond(MockRestResponseCreators.withStatus(HttpStatus.TOO_MANY_REQUESTS));
+
+        Map<String, Map<String, Double>> result = client.fetchUsdPricesByIds(Set.of("bitcoin"));
+        assertTrue(result.isEmpty());
+
+        server.verify();
+    }
+}


### PR DESCRIPTION
## Summary
- log and gracefully return empty prices when CoinGecko responds with HTTP 429
- throw `CoinGeckoClientException` for other CoinGecko errors
- add unit test covering rate-limit handling

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68aa63aae1f08326b6b7f616fb368fc5