### PR TITLE
test: track APY per wallet

### DIFF
--- a/backend/src/test/java/app/dya/service/ApyTrackingServiceTest.java
+++ b/backend/src/test/java/app/dya/service/ApyTrackingServiceTest.java
@@ -38,10 +38,35 @@ class ApyTrackingServiceTest {
                 "OK",
                 "DEPOSIT"
         );
+        PortfolioDTO.PositionDTO evenLower = new PortfolioDTO.PositionDTO(
+                "Aave",
+                "ethereum",
+                "DAI",
+                BigDecimal.ONE,
+                BigDecimal.ONE,
+                new BigDecimal("0.03"),
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                "OK",
+                "DEPOSIT"
+        );
+
+        // first wallet sets baseline then triggers alert on drop
         Optional<AlertItem> first = service.checkApy("0xabc", initial);
         assertTrue(first.isEmpty());
+
+        // second wallet is new; first call yields no alert
+        Optional<AlertItem> emptySecond = service.checkApy("0xdef", lower);
+        assertTrue(emptySecond.isEmpty());
+
+        // first wallet experiences drop and triggers alert
         Optional<AlertItem> alert = service.checkApy("0xabc", lower);
         assertTrue(alert.isPresent());
         assertEquals("YIELD_DROP", alert.get().type());
+
+        // second wallet drops further and also triggers alert
+        Optional<AlertItem> secondAlert = service.checkApy("0xdef", evenLower);
+        assertTrue(secondAlert.isPresent());
+        assertEquals("YIELD_DROP", secondAlert.get().type());
     }
 }


### PR DESCRIPTION
## Summary
- extend APY tracking tests to verify alerts are scoped per wallet
- cover empty-wallet case where first call produces no alert

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68aad4ba0fd88326b96b200fb1d57d5c