### PR TITLE
Add test for empty positions when subgraph user missing

### DIFF
--- a/backend/src/test/java/app/dya/service/aave/AaveV3ServiceTest.java
+++ b/backend/src/test/java/app/dya/service/aave/AaveV3ServiceTest.java
@@ -63,5 +63,27 @@ class AaveV3ServiceTest {
         assertThat(borrow.positionType()).isEqualTo("BORROW");
         assertThat(borrow.riskStatus()).isEqualTo("OK");
     }
+
+    @Test
+    void returnsEmptyListWhenUserIsNull() {
+        RestTemplate restTemplate = new RestTemplate();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(restTemplate).ignoreExpectOrder(true).build();
+
+        AaveV3Service service = new AaveV3Service(new RestTemplateBuilder() {
+            @Override
+            public RestTemplate build() {
+                return restTemplate;
+            }
+        }, "http://example.com");
+
+        String body = "{\"data\":{\"user\":null}}";
+
+        server.expect(requestTo("http://example.com"))
+                .andExpect(method(org.springframework.http.HttpMethod.POST))
+                .andRespond(withSuccess(body, MediaType.APPLICATION_JSON));
+
+        List<PortfolioDTO.PositionDTO> positions = service.getPositions("0xabc");
+        assertThat(positions).isEmpty();
+    }
 }
 


### PR DESCRIPTION
## Summary
- add unit test ensuring AaveV3Service returns no positions when subgraph 'user' is null

## Testing
- `cd backend && ./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68aae291fac48326ad5fabde15f70e3c