### PR TITLE
Allow Netlify cross-origin requests

### DIFF
--- a/backend/src/main/java/app/dya/api/AlertsController.java
+++ b/backend/src/main/java/app/dya/api/AlertsController.java
@@ -26,7 +26,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/alerts")
-@CrossOrigin(origins = "http://localhost:5173")
+@CrossOrigin(origins = "*")
 public class AlertsController {
 
     private static final BigDecimal RISK_THRESHOLD = new BigDecimal("1.3");

--- a/backend/src/main/java/app/dya/api/PortfolioController.java
+++ b/backend/src/main/java/app/dya/api/PortfolioController.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/portfolio")
-@CrossOrigin(origins = "http://localhost:5173")
+@CrossOrigin(origins = "*")
 public class PortfolioController {
 
     private final AaveV3Service aaveV3Service;

--- a/backend/src/main/java/app/dya/price/PriceController.java
+++ b/backend/src/main/java/app/dya/price/PriceController.java
@@ -7,7 +7,7 @@ import java.util.*;
 
 @RestController
 @RequestMapping("/prices")
-@CrossOrigin(origins = "http://localhost:5173")
+@CrossOrigin(origins = "*")
 public class PriceController {
 
     private final PriceService svc;


### PR DESCRIPTION
## Summary
- Allow cross-origin requests from any origin for Alerts, Portfolio, and Price controllers to ease Netlify/Heroku integration

## Testing
- `./gradlew test`
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68ae61faa8808326b87e5f7e8b98b01e