### PR TITLE
chore(frontend): add production API base URL env file

### DIFF
--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,1 @@
+VITE_API_BASE=https://defi-yield-aggregator-591a51c34153.herokuapp.com


### PR DESCRIPTION
## Summary
- add `.env.production` to expose correct API base URL during build

## Testing
- `npm test -- --environment jsdom`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae6b83b2a883268dcc21813aba30d3